### PR TITLE
correct a mistake in installation guide in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is where your description should go. Limit it to a paragraph or two. Consid
 You can install the package via composer:
 
 ```bash
-composer require solutionforest/time-range-slider
+composer require solution-forest/filament-time-range-slider
 ```
 
 You can publish the views using


### PR DESCRIPTION
both vendor and package name are different than what the package is registers as, in packagist.org.
so the `composer require solutionforest/time-range-slider` raised the `Could not find a matching version of package solutionforest/time-range-slider` error.

this PR fixed that mistake.